### PR TITLE
ignore .ready and .backup files in find query

### DIFF
--- a/pgsql/walarchivecleanup.sh
+++ b/pgsql/walarchivecleanup.sh
@@ -87,7 +87,7 @@ fi
 if [[ $debug = true ]]; then cmd_debug="-d"; fi
 if [[ $dry = true ]]; then cmd_dry="-n"; fi
 if [[ -n $age ]] && [[ -z $archivefile ]]; then
-  cmd_file="$(find ${archivepath}/ -type f -mtime +${age} -printf "%C@ %f\n" |sort -n | tail -n 1 | awk '{print $NF}')"
+  cmd_file="$(find ${archivepath}/ -type f -not -name '*.ready' -not -name '*.backup' -mtime +${age} -printf "%C@ %f\n" | sort -n | tail -n 1 | cut -f2 -d' '
 else
   cmd_file="$archivefile"
 fi


### PR DESCRIPTION
 - `.ready` and `.backup` files may be present in the WAL directory, but are not valid arguments to `pg_archivecleanup`
 - using `cut` is probably cheaper than `awk`