### PR TITLE
Zoneminder cleanup script improvement

### DIFF
--- a/zoneminder/zoneminder-event-cleanup.sh
+++ b/zoneminder/zoneminder-event-cleanup.sh
@@ -12,9 +12,10 @@
 # 2020-08-06 changed for zoneminder 1.24+ (@Brawn1)
 # 2020-08-07 remove complexity and docker parts (@Brawn1)
 # 2021-03-08 Export MYSQL_PWD (fix issue #6)
+# 2021-08-28 Added transactional processing, progress indicator and truncate log option (@cmilanf)
 ###########################################################################
 # User variables
-olderthan=2 # Defines the minimum age in days of the events to be deleted
+olderthan=60 # Defines the minimum age in days of the events to be deleted
 zmcache=/var/cache/zoneminder/events # Defines the path where zm stores events
 mysqlhost=localhost # Defines the MySQL host for the zm database
 mysqldb=zm # Defines the MySQL database name used by zm
@@ -22,6 +23,10 @@ mysqluser=zoneminder # Defines a MySQL user to connect to the database
 mysqlpass=zm-mysql-password # Defines the password for the MySQL user
 export MYSQL_PWD=${mysqlpass}
 zm_linked_version="" # set "true" if using zoneminder pre 1.24 (old version with symlinks instead directories by events)
+truncate_logs="true" # set "true" if you want to truncate Log table
+
+# Spin progress
+spin='-\|/'
 
 # Fixed variables
 tmpfile=/tmp/$RANDOM
@@ -43,12 +48,18 @@ else
   find ${zmcache}/ -mindepth 3 -maxdepth 3 -type d -mtime +${olderthan} ${findexception[*]} -exec ls -ld {} + > $tmpfile
 fi
 
+num_events=$(wc -l < $tmpfile)
 # For each found event...
+i=0
+j=0
 while read line; do
+  i=$(( (i+1) %4 ))
+  j=$((j+1))
+  printf "\r[${spin:$i:1}] ($j/$num_events) "
   # Get the event ID
   eventid=$(echo $line | awk '{print $9}' | awk -F'/' '{print $NF}' | sed "s/\.//g")
   realpath=$(echo $line | awk '{print $9"/"$11}'  | sed "s/\.[0-9]*\///g")
-  echo "Deleting Event Id=$eventid"
+  echo -n "Deleting Event Id=$eventid"
   
   if [[ ! -z ${zm_linked_version} ]]; then
     symlink=$(echo $line | awk '{print $9}')
@@ -61,9 +72,19 @@ while read line; do
   fi
   
   # delete eventid from database
-  mysql -h ${mysqlhost} -N -u ${mysqluser} -e "DELETE FROM ${mysqldb}.Events where Id = $eventid"
-  mysql -h ${mysqlhost} -N -u ${mysqluser} -e "DELETE FROM ${mysqldb}.Frames where EventId = $eventid"
-  mysql -h ${mysqlhost} -N -u ${mysqluser} -e "DELETE FROM ${mysqldb}.Stats where EventId = $eventid"
+  mysql_query="START TRANSACTION;
+          DELETE FROM ${mysqldb}.Events where Id = $eventid;
+	  DELETE FROM ${mysqldb}.Frames where EventId = $eventid;
+	  DELETE FROM ${mysqldb}.Stats where EventId = $eventid;
+	  COMMIT;"
+  mysql -h ${mysqlhost} -N -u ${mysqluser} -e "${mysql_query}"
 done < $tmpfile
+echo "Event clean-up finished!"
+# truncate log table
+if [[ ! -z ${truncate_logs} ]]; then
+	echo "Truncating Logs table..."
+	mysql -h ${mysqlhost} -N -u ${mysqluser} -e "TRUNCATE TABLE ${mysqldb}.Logs"
+	echo "Logs clean-up finished!"
+fi
 
 exit 0


### PR DESCRIPTION
This patch adds the following improvements to the ZoneMinder clean-up script:
  * Instead of launching 3 separate `mysql` commands, we will now use just one that performs the event deletion with a transaction. Even with the transaction mechanism, it is faster than previous way.
  * Added a progress indicator.
  * Added an option to truncate the `Logs` table, preventing it to become too big.